### PR TITLE
Fix NEI handler for crushing and washing

### DIFF
--- a/java/k4unl/minecraft/Hydraulicraft/thirdParty/nei/NEICrusherRecipeManager.java
+++ b/java/k4unl/minecraft/Hydraulicraft/thirdParty/nei/NEICrusherRecipeManager.java
@@ -97,15 +97,12 @@ public class NEICrusherRecipeManager extends ShapedRecipeHandler {
 
     @Override
     public void loadCraftingRecipes(String outputId, Object... results) {
-    	if(getClass() == NEICrusherRecipeManager.class && results.length > 0) {
-            if(results[0] instanceof ItemStack){ //Because Mariculture can't be assed to fix this.
-                for(CrushingRecipes.CrushingRecipe recipe: CrushingRecipes.crushingRecipes) {
-                    if(recipe.output.isItemEqual((ItemStack) results[0])){
-                        this.arecipes.add(getShape(recipe));
-                    }
-                }
+    	if(outputId.equals("crushing")){
+            for(CrushingRecipes.CrushingRecipe recipe: CrushingRecipes.crushingRecipes){
+                this.arecipes.add(getShape(recipe));
             }
-    	}
+    	}else
+    		super.loadCraftingRecipes(outputId, results);
     }
     
     @Override

--- a/java/k4unl/minecraft/Hydraulicraft/thirdParty/nei/NEIWasherRecipeManager.java
+++ b/java/k4unl/minecraft/Hydraulicraft/thirdParty/nei/NEIWasherRecipeManager.java
@@ -1,5 +1,8 @@
 package k4unl.minecraft.Hydraulicraft.thirdParty.nei;
 
+import java.awt.Rectangle;
+import java.util.LinkedList;
+
 import k4unl.minecraft.Hydraulicraft.client.GUI.GuiCrusher;
 import k4unl.minecraft.Hydraulicraft.client.GUI.IconRenderer;
 import k4unl.minecraft.Hydraulicraft.lib.Localization;
@@ -74,17 +77,19 @@ public class NEIWasherRecipeManager extends ShapedRecipeHandler{
 
     @Override
     public void loadCraftingRecipes(String outputId, Object... results) {
-        if(outputId.equals("crafting") && getClass() ==
-                NEIWasherRecipeManager.class) {
+        if(outputId.equals("washing")){
             for(WashingRecipes.WashingRecipe recipe: WashingRecipes.washingRecipes) {
                 this.arecipes.add(getShape(recipe));
             }
+        }else{
+        	super.loadCraftingRecipes(outputId, results);
         }
     }
     
     @Override
     public void loadTransferRects(){
-    	
+    	transferRects = new LinkedList<RecipeTransferRect>();
+        transferRects.add(new RecipeTransferRect(new Rectangle(74, 28, 35, 20), "washing"));
     }
     
     @Override


### PR DESCRIPTION
Whilst testing my AOBD support I noticed that clicking the "recipes" rectangle when looking up crushing/washing recipes on NEI was broken, so I thought I'd fix it for you :)

Oh and I also finished AOBD support for Hydraulicraft :D
